### PR TITLE
chore: Remove rebase option from Renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -10,6 +10,7 @@
 	"ignoreDeps": [],
 	"prHourlyLimit": 0,
 	"prConcurrentLimit": 0,
+  	"prBodyTemplate": "{{{header}}}{{{table}}}{{{notes}}}{{{changelogs}}}{{{configDescription}}}{{{footer}}}",
 	"extends": [
 		"config:base",
 		"default:pinDigestsDisabled"


### PR DESCRIPTION
Remove rebase option from Renovate to use auto-merge.