### PR TITLE
chore: Migrate to new Issue Forms YAML spec

### DIFF
--- a/.github/ISSUE_TEMPLATE/1_Event_type_request.yml
+++ b/.github/ISSUE_TEMPLATE/1_Event_type_request.yml
@@ -1,15 +1,16 @@
-name: Event type request ⚡ (Legacy)
+name: Event type request ⚡
 about: Suggest a new event type that would be an added value
 labels: "bug"
 assignees: tomkerkhove
 issue_body: true
-inputs:
+body:
 - type: input
   attributes:
     label: Contact Details
     description: How can we get in touch with you if we need more info?
-    required: false
     placeholder: ex. email@example.com
+  validations:
+    required: false
 - type: textarea
   attributes:
     label: Scenario
@@ -20,36 +21,40 @@ inputs:
     label: Proposed Event Type
     description: "What event type would you propose?"
     placeholder: "A proposal for the event type, for example `Kubernetes.ClusterAutoscaler.Scale.Out`."
+  validations:
     required: false
 - type: textarea
   attributes:
     label: Proposed Event Payload
     description: What event payload would you propose?
     placeholder: "A proposal for the event payload that you would like to have."
-    required: false
     value: |
       ```json
       {
         "key": "value"
       }
       ```
+  validations:
+    required: false
 - type: textarea
   attributes:
     label: Raw Kubernetes Event
     description: What is the raw Kubernetes event that we should convert for this event?
     placeholder: "A raw Kubernetes event payload that is the source."
-    required: false
     value: |
       ```json
       {
         "key": "value"
       }
       ```
+  validations:
+    required: false
 - type: dropdown
   attributes:
     label: Source Component
     description: What component is emitting the original raw event?
-    required: false
-    choices:
+    options:
     - Kubernetes Control Plane
     - Other
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/2_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/2_feature_request.yml
@@ -1,9 +1,9 @@
-name: Feature request 🧭 (Legacy)
+name: Feature request 🧭
 about: Suggest an idea for this project
 labels: "feature-request"
 assignees: tomkerkhove
 issue_body: true
-inputs:
+body:
 - type: textarea
   attributes:
     label: Proposal
@@ -13,5 +13,7 @@ inputs:
   attributes:
     label: Contact Details
     description: How can we get in touch with you if we need more info?
-    required: false
     placeholder: ex. email@example.com
+  validations:
+    required: false
+    

--- a/.github/ISSUE_TEMPLATE/3_bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/3_bug-report.yml
@@ -1,9 +1,9 @@
-name: Report a bug 🐛 (Legacy)
+name: Report a bug 🐛
 about: Create a report to help us improve
 labels: "bug"
 assignees: tomkerkhove
 issue_body: true
-inputs:
+body:
 - type: textarea
   attributes:
     label: Report
@@ -13,20 +13,23 @@ inputs:
   attributes:
     label: Contact Details
     description: How can we get in touch with you if we need more info?
-    required: false
     placeholder: ex. email@example.com
+  validations:
+    required: false
 - type: textarea
   attributes:
     label: Expected Behavior
     description: What did you expect to happen?
-    required: true
     placeholder: What did you expect to happen?
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Actual Behavior
     description: Also tell us, what did you see is happen?
-    required: true
     placeholder: Tell us what you see that is happening
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Steps to Reproduce the Problem
@@ -36,23 +39,26 @@ inputs:
       2.
       3.
       ...
+  validations:
     required: true
 - type: dropdown
   attributes:
     label: Version
     description: What version of our software are you running?
-    required: false
-    choices:
+    options:
     - 0.1.0
     - experimental
+  validations:
+    required: false
 - type: dropdown
   attributes:
     label: Platform
     description: Where is your cluster running?
-    required: false
-    choices:
+    options:
     - Microsoft Azure
     - Amazon Web Services
     - Google Cloud
     - Alibaba Cloud
     - Other
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/Event_type_request.yml
+++ b/.github/ISSUE_TEMPLATE/Event_type_request.yml
@@ -3,13 +3,14 @@ about: Suggest a new event type that would be an added value
 labels: "bug"
 assignees: tomkerkhove
 issue_body: true
-inputs:
+body:
 - type: input
   attributes:
     label: Contact Details
     description: How can we get in touch with you if we need more info?
-    required: false
     placeholder: ex. email@example.com
+  validations:
+    required: false
 - type: textarea
   attributes:
     label: Scenario
@@ -20,36 +21,40 @@ inputs:
     label: Proposed Event Type
     description: "What event type would you propose?"
     placeholder: "A proposal for the event type, for example `Kubernetes.ClusterAutoscaler.Scale.Out`."
+  validations:
     required: false
 - type: textarea
   attributes:
     label: Proposed Event Payload
     description: What event payload would you propose?
     placeholder: "A proposal for the event payload that you would like to have."
-    required: false
     value: |
       ```json
       {
         "key": "value"
       }
       ```
+  validations:
+    required: false
 - type: textarea
   attributes:
     label: Raw Kubernetes Event
     description: What is the raw Kubernetes event that we should convert for this event?
     placeholder: "A raw Kubernetes event payload that is the source."
-    required: false
     value: |
       ```json
       {
         "key": "value"
       }
       ```
+  validations:
+    required: false
 - type: dropdown
   attributes:
     label: Source Component
     description: What component is emitting the original raw event?
-    required: false
-    choices:
+    options:
     - Kubernetes Control Plane
     - Other
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -3,7 +3,7 @@ about: Create a report to help us improve
 labels: "bug"
 assignees: tomkerkhove
 issue_body: true
-inputs:
+body:
 - type: textarea
   attributes:
     label: Report
@@ -13,20 +13,23 @@ inputs:
   attributes:
     label: Contact Details
     description: How can we get in touch with you if we need more info?
-    required: false
     placeholder: ex. email@example.com
+  validations:
+    required: false
 - type: textarea
   attributes:
     label: Expected Behavior
     description: What did you expect to happen?
-    required: true
     placeholder: What did you expect to happen?
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Actual Behavior
     description: Also tell us, what did you see is happen?
-    required: true
     placeholder: Tell us what you see that is happening
+  validations:
+    required: true
 - type: textarea
   attributes:
     label: Steps to Reproduce the Problem
@@ -36,23 +39,26 @@ inputs:
       2.
       3.
       ...
+  validations:
     required: true
 - type: dropdown
   attributes:
     label: Version
     description: What version of our software are you running?
-    required: false
-    choices:
+    options:
     - 0.1.0
     - experimental
+  validations:
+    required: false
 - type: dropdown
   attributes:
     label: Platform
     description: Where is your cluster running?
-    required: false
-    choices:
+    options:
     - Microsoft Azure
     - Amazon Web Services
     - Google Cloud
     - Alibaba Cloud
     - Other
+  validations:
+    required: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -3,7 +3,7 @@ about: Suggest an idea for this project
 labels: "feature-request"
 assignees: tomkerkhove
 issue_body: true
-inputs:
+body:
 - type: textarea
   attributes:
     label: Proposal
@@ -13,5 +13,7 @@ inputs:
   attributes:
     label: Contact Details
     description: How can we get in touch with you if we need more info?
-    required: false
     placeholder: ex. email@example.com
+  validations:
+    required: false
+    


### PR DESCRIPTION
Migrate to new Issue Forms YAML spec as per gh-community.github.io/issue-template-feedback/changes which is taking affect tomorrow.

