### PR TITLE
chore: Provide new sample events from Kubernetes

### DIFF
--- a/events/core/FailedCreatePodSandBox.json
+++ b/events/core/FailedCreatePodSandBox.json
@@ -1,0 +1,40 @@
+{
+	"metadata": {
+		"name": "frontend-dtjf5.1675f3de40d4037d",
+		"namespace": "default",
+		"selfLink": "/api/v1/namespaces/default/events/frontend-dtjf5.1675f3de40d4037d",
+		"uid": "ac5314ce-6f92-4f5a-a2d7-f51316105126",
+		"resourceVersion": "24231421",
+		"creationTimestamp": "2021-04-15T06:22:57Z",
+		"managedFields": [{
+			"manager": "kubelet",
+			"operation": "Update",
+			"apiVersion": "v1",
+			"time": "2021-04-15T06:22:57Z"
+		}]
+	},
+	"reason": "FailedCreatePodSandBox",
+	"message": "Failed to create pod sandbox: rpc error: code = Unknown desc = failed to start sandbox container task \"0a82fde7c4390a9050b0381a1be0e71671b38e46c25f9f7e0837f283f3bac9ad\": OCI runtime start failed: cannot start a container that has stopped: unknown",
+	"source": {
+		"component": "kubelet",
+		"host": "aks-agentpool-11593772-vmss000000"
+	},
+	"firstTimestamp": "2021-04-15T06:22:57Z",
+	"lastTimestamp": "2021-04-15T06:22:57Z",
+	"count": 1,
+	"type": "Warning",
+	"eventTime": null,
+	"reportingComponent": "",
+	"reportingInstance": "",
+	"involvedObject": {
+		"kind": "Pod",
+		"namespace": "default",
+		"name": "frontend-dtjf5",
+		"uid": "94c9fbb6-e0ae-4543-86e1-18f139ae2db1",
+		"apiVersion": "v1",
+		"resourceVersion": "24231333",
+		"labels": {
+			"tier": "frontend"
+		}
+	}
+}

--- a/events/core/PodUnhealthyDueToHealthProbe.json
+++ b/events/core/PodUnhealthyDueToHealthProbe.json
@@ -1,0 +1,42 @@
+{
+	"metadata": {
+		"name": "coredns-autoscaler-5b6cbd75d7-rf47t.1675f3df24a918d1",
+		"namespace": "kube-system",
+		"selfLink": "/api/v1/namespaces/kube-system/events/coredns-autoscaler-5b6cbd75d7-rf47t.1675f3df24a918d1",
+		"uid": "fb4abf18-3e36-49eb-8a22-9dbe04c8a7d3",
+		"resourceVersion": "24231436",
+		"creationTimestamp": "2021-04-15T06:23:00Z",
+		"managedFields": [{
+			"manager": "kubelet",
+			"operation": "Update",
+			"apiVersion": "v1",
+			"time": "2021-04-15T06:23:00Z"
+		}]
+	},
+	"reason": "Unhealthy",
+	"message": "Liveness probe failed: Get \"http://10.244.0.7:8080/last-poll\": context deadline exceeded (Client.Timeout exceeded while awaiting headers)",
+	"source": {
+		"component": "kubelet",
+		"host": "aks-agentpool-11593772-vmss000000"
+	},
+	"firstTimestamp": "2021-04-15T06:23:00Z",
+	"lastTimestamp": "2021-04-15T06:23:00Z",
+	"count": 1,
+	"type": "Warning",
+	"eventTime": null,
+	"reportingComponent": "",
+	"reportingInstance": "",
+	"involvedObject": {
+		"kind": "Pod",
+		"namespace": "kube-system",
+		"name": "coredns-autoscaler-5b6cbd75d7-rf47t",
+		"uid": "21db1050-abb4-47e3-bb0c-c333bc80c225",
+		"apiVersion": "v1",
+		"resourceVersion": "840",
+		"fieldPath": "spec.containers{autoscaler}",
+		"labels": {
+			"k8s-app": "coredns-autoscaler",
+			"pod-template-hash": "5b6cbd75d7"
+		}
+	}
+}

--- a/events/core/PodUnhealthyDueToReadinessProbe.json
+++ b/events/core/PodUnhealthyDueToReadinessProbe.json
@@ -1,0 +1,42 @@
+{
+	"metadata": {
+		"name": "metrics-server-77c8679d7d-tsdpq.165910f5e7077e3c",
+		"namespace": "kube-system",
+		"selfLink": "/api/v1/namespaces/kube-system/events/metrics-server-77c8679d7d-tsdpq.165910f5e7077e3c",
+		"uid": "f43d0bd2-2b95-48d3-a505-6f800c96cea6",
+		"resourceVersion": "24231435",
+		"creationTimestamp": "2021-04-15T06:23:00Z",
+		"managedFields": [{
+			"manager": "kubelet",
+			"operation": "Update",
+			"apiVersion": "v1",
+			"time": "2021-04-15T06:23:00Z"
+		}]
+	},
+	"reason": "Unhealthy",
+	"message": "Readiness probe failed: Get \"https://10.244.0.3:443/healthz\": net/http: request canceled (Client.Timeout exceeded while awaiting headers)",
+	"source": {
+		"component": "kubelet",
+		"host": "aks-agentpool-11593772-vmss000000"
+	},
+	"firstTimestamp": "2021-01-11T03:49:50Z",
+	"lastTimestamp": "2021-04-15T06:23:00Z",
+	"count": 19,
+	"type": "Warning",
+	"eventTime": null,
+	"reportingComponent": "",
+	"reportingInstance": "",
+	"involvedObject": {
+		"kind": "Pod",
+		"namespace": "kube-system",
+		"name": "metrics-server-77c8679d7d-tsdpq",
+		"uid": "3e7da7be-4c5a-47cf-8613-719c0afde77b",
+		"apiVersion": "v1",
+		"resourceVersion": "836",
+		"fieldPath": "spec.containers{metrics-server}",
+		"labels": {
+			"k8s-app": "metrics-server",
+			"pod-template-hash": "77c8679d7d"
+		}
+	}
+}

--- a/events/core/PodVolumeMountFailed.json
+++ b/events/core/PodVolumeMountFailed.json
@@ -1,0 +1,41 @@
+{
+	"metadata": {
+		"name": "frontend-zshp9.1675f3e79ed67fa5",
+		"namespace": "default",
+		"selfLink": "/api/v1/namespaces/default/events/frontend-zshp9.1675f3e79ed67fa5",
+		"uid": "56f2cb2e-4812-48b0-ad3e-556bed8cc191",
+		"resourceVersion": "24231542",
+		"creationTimestamp": "2021-04-15T06:23:37Z",
+		"managedFields": [{
+			"manager": "kubelet",
+			"operation": "Update",
+			"apiVersion": "v1",
+			"time": "2021-04-15T06:23:37Z"
+		}]
+	},
+	"reason": "Failed",
+	"message": "Error: cannot find volume \"default-token-wjk8j\" to mount into container \"php-redis\"",
+	"source": {
+		"component": "kubelet",
+		"host": "aks-agentpool-11593772-vmss000000"
+	},
+	"firstTimestamp": "2021-04-15T06:23:37Z",
+	"lastTimestamp": "2021-04-15T06:23:37Z",
+	"count": 1,
+	"type": "Warning",
+	"eventTime": null,
+	"reportingComponent": "",
+	"reportingInstance": "",
+	"involvedObject": {
+		"kind": "Pod",
+		"namespace": "default",
+		"name": "frontend-zshp9",
+		"uid": "cd72f718-d40f-47f0-b15e-6dd360e69f34",
+		"apiVersion": "v1",
+		"resourceVersion": "24231332",
+		"fieldPath": "spec.containers{php-redis}",
+		"labels": {
+			"tier": "frontend"
+		}
+	}
+}


### PR DESCRIPTION
Signed-off-by: Tom Kerkhove <kerkhove.tom@gmail.com>

Provide new sample events from Kubernetes:
- Pod volume mount failed
- Pod liveness probe failed
- Pod readiness probe failed
- Pod sandbox container failed to create